### PR TITLE
New loader logic to load first pum templates

### DIFF
--- a/src/Pum/Bundle/CoreBundle/DependencyInjection/Compiler/PumLoaderPass.php
+++ b/src/Pum/Bundle/CoreBundle/DependencyInjection/Compiler/PumLoaderPass.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Pum\Bundle\CoreBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+
+class PumLoaderPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        $definition = $container->getDefinition('twig');
+        $definition->addMethodCall('setLoader', array(new Reference('pum.chain.loader')));
+    }
+}

--- a/src/Pum/Bundle/CoreBundle/PumCoreBundle.php
+++ b/src/Pum/Bundle/CoreBundle/PumCoreBundle.php
@@ -5,6 +5,7 @@ namespace Pum\Bundle\CoreBundle;
 use Pum\Bundle\CoreBundle\DependencyInjection\Compiler\AddValidationLoaderPass;
 use Pum\Bundle\CoreBundle\DependencyInjection\Compiler\PumSubscriberPass;
 use Pum\Bundle\CoreBundle\DependencyInjection\Compiler\BuilderRegistryPass;
+use Pum\Bundle\CoreBundle\DependencyInjection\Compiler\PumLoaderPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -17,5 +18,6 @@ class PumCoreBundle extends Bundle
         $container->addCompilerPass(new BuilderRegistryPass());
         $container->addCompilerPass(new PumSubscriberPass());
         $container->addCompilerPass(new AddValidationLoaderPass());
+        $container->addCompilerPass(new PumLoaderPass());
     }
 }

--- a/src/Pum/Bundle/CoreBundle/Resources/config/pum.xml
+++ b/src/Pum/Bundle/CoreBundle/Resources/config/pum.xml
@@ -56,7 +56,7 @@
         </service>
 
         <service id="pum.form_ajax" class="Pum\Bundle\CoreBundle\Form\AjaxService">
-            <argument type="service" id="pum.view" />
+            <argument type="service" id="pum.view" on-invalid="ignore" />
         </service>
 
         <!-- TYPES (must be public, lazy loaded) -->
@@ -96,6 +96,21 @@
         <service id="pum.type.relation" class="Pum\Core\Extension\Core\Type\RelationType">
             <tag name="pum.type" alias="relation" />
         </service>
+
+        <!-- CHAIN VIEW LOADER -->
+
+        <service id="pum.chain.loader" class="Twig_Loader_Chain">
+            <call method="addLoader">
+                <argument type="service" id="pum.view_loader.dbal" on-invalid="ignore" />
+            </call>
+            <call method="addLoader">
+                <argument type="service" id="pum.view_loader.filessystem" on-invalid="ignore" />
+            </call>
+            <call method="addLoader">
+                <argument type="service" id="twig.loader" />
+            </call>
+        </service>
+
 
     </services>
 </container>

--- a/src/Pum/Bundle/CoreBundle/Resources/config/view_dbal.xml
+++ b/src/Pum/Bundle/CoreBundle/Resources/config/view_dbal.xml
@@ -24,8 +24,6 @@
 
         <service id="pum_core.view_loader.dbal" class="Pum\Core\Extension\View\Loader\PumMySqlLoader" public="false">
             <argument type="service" id="pum.view_storage.dbal" />
-
-            <tag name="twig.loader" />
         </service>
 
         <!-- VIEW FEATURE -->

--- a/src/Pum/Bundle/CoreBundle/Resources/config/view_filesystem.xml
+++ b/src/Pum/Bundle/CoreBundle/Resources/config/view_filesystem.xml
@@ -15,8 +15,8 @@
 
         <service id="pum_core.view_loader.filessystem" class="Pum\Core\Extension\View\Loader\PumFilesystemLoader" public="false">
             <argument>%pum_core.view.folders%</argument>
+            <argument type="service" id="templating.name_parser"/>
 
-            <tag name="twig.loader" />
         </service>
 
     </services>


### PR DESCRIPTION
- new `exists()` method in `PumFilesystemLoader` to find Twig logical named templates in pum views directory ( ie: to handle exception templates, it will search in `pum_views/TwigBundle/Exception/error.html.twig` )
- new chain loader to handle Pum templates first
