### PR TITLE
Allow duplicate entity manager

### DIFF
--- a/src/Pum/Bundle/CoreBundle/PumContext.php
+++ b/src/Pum/Bundle/CoreBundle/PumContext.php
@@ -165,16 +165,17 @@ class PumContext
     }
 
     /**
+     * @param String $entityManagerName
      * @return \Doctrine\Common\Persistence\ObjectManager
      * @throws \RuntimeException The project is not set in context.
      */
-    public function getProjectOEM()
+    public function getProjectOEM($entityManagerName = 'default')
     {
         if (null === $this->projectName) {
             throw new \RuntimeException(sprintf('Project name is missing from PUM context.'));
         }
 
-        return $this->container->get('em_factory')->getManager($this->container->get('pum'), $this->projectName);
+        return $this->container->get('em_factory')->getManager($this->container->get('pum'), $this->projectName, $entityManagerName);
     }
 
     /**

--- a/src/Pum/Core/Extension/EmFactory/EmFactory.php
+++ b/src/Pum/Core/Extension/EmFactory/EmFactory.php
@@ -57,19 +57,20 @@ class EmFactory
      *
      * @param ObjectFactory $objectFactory
      * @param String $projectName
+     * @param String $entityManagerName
      * @return \Doctrine\Common\Persistence\ObjectManager
      */
-    public function getManager(ObjectFactory $objectFactory, $projectName)
+    public function getManager(ObjectFactory $objectFactory, $projectName, $entityManagerName = 'default')
     {
         if ($projectName instanceof Project) {
             $projectName = $projectName->getName();
         }
 
-        if (isset($this->entityManagers[$projectName])) {
-            return $this->entityManagers[$projectName];
+        if (isset($this->entityManagers[$projectName . $entityManagerName])) {
+            return $this->entityManagers[$projectName . $entityManagerName];
         }
 
-        return $this->entityManagers[$projectName] = $this->createManager($objectFactory, $projectName);
+        return $this->entityManagers[$projectName . $entityManagerName] = $this->createManager($objectFactory, $projectName);
     }
 
     private function createManager(ObjectFactory $objectFactory, $projectName)


### PR DESCRIPTION
Add a name parameter to the method getProjectOEM to allow a user to
duplicate the entity manager of the project
