### PR TITLE
Add default "empty_value" when choice field not required

### DIFF
--- a/src/Pum/Core/Extension/Core/Type/ChoiceType.php
+++ b/src/Pum/Core/Extension/Core/Type/ChoiceType.php
@@ -99,7 +99,7 @@ class ChoiceType extends AbstractType
             ->add($context->getField()->getLowercaseName(), 'choice', array(
                 'choices'     => $context->getOption('choices'),
                 'required'    => $context->getOption('required'),
-                'placeholder' => $formViewField->getOption('empty_value', false),
+                'placeholder' => $context->getOption('required') ? false : $formViewField->getOption('empty_value', '—'),
                 'label'       => $formViewField->getLabel(),
                 'expanded'    => $formViewField->getOption('expanded'),
                 'multiple'    => $formViewField->getOption('multiple'),


### PR DESCRIPTION
Changed `empty_value` (`placeholder` in Symfony 2.6) to a default value instead of `false` when the field is not required to avoid one value set when submitting the form even if we doesn't want to set a value yet.
Still possibility to change this `empty_value` from FormView Field options to something else than the default value.

When field is required, `empty_value` still set to `false`.
