### PR TITLE
Add `remote` attr to YAAH modal links

### DIFF
--- a/src/Pum/Bundle/AppBundle/Resources/views/macros.html.twig
+++ b/src/Pum/Bundle/AppBundle/Resources/views/macros.html.twig
@@ -280,8 +280,8 @@
     {% if app.request.xmlHttpRequest %}
         {% set xhrLinksHref = 'href' %}
         {% set xhrLinksClass = 'yaah-js' %}
-        {% set xhrLinksAttr = ' data-target="#pumAjaxModal" data-ya-target="#pumAjaxModal .modal-content" data-ya-location="inner"' %}
-        {% set xhrLinksCancelAttr = ' data-target="#pumAjaxModal" data-ya-target="#pumAjaxModal .modal-content" data-ya-location="inner" data-ya-trigger="manual"' %}
+        {% set xhrLinksAttr = ' data-target="#pumAjaxModal" data-ya-target="#pumAjaxModal .modal-content" data-ya-location="inner" data-remote="false"' %}
+        {% set xhrLinksCancelAttr = ' data-target="#pumAjaxModal" data-ya-target="#pumAjaxModal .modal-content" data-ya-location="inner" data-ya-trigger="manual" data-remote="false"' %}
     {% else %}
         {% set xhrLinksHref = 'href' %}
         {% set xhrLinksClass = '' %}
@@ -358,8 +358,8 @@
     {% if app.request.xmlHttpRequest %}
         {% set xhrLinksHref = 'href' %}
         {% set xhrLinksClass = 'yaah-js' %}
-        {% set xhrLinksAttr = ' data-target="#pumAjaxModal" data-ya-target="#pumAjaxModal .modal-content" data-ya-location="inner"' %}
-        {% set xhrLinksCancelAttr = ' data-target="#pumAjaxModal" data-ya-target="#pumAjaxModal .modal-content" data-ya-location="inner" data-ya-trigger="manual"' %}
+        {% set xhrLinksAttr = ' data-target="#pumAjaxModal" data-ya-target="#pumAjaxModal .modal-content" data-ya-location="inner" data-remote="false"' %}
+        {% set xhrLinksCancelAttr = ' data-target="#pumAjaxModal" data-ya-target="#pumAjaxModal .modal-content" data-ya-location="inner" data-ya-trigger="manual" data-remote="false"' %}
     {% else %}
         {% set xhrLinksHref = 'href' %}
         {% set xhrLinksClass = '' %}

--- a/src/Pum/Bundle/ProjectAdminBundle/Resources/views/FormView/create.html.twig
+++ b/src/Pum/Bundle/ProjectAdminBundle/Resources/views/FormView/create.html.twig
@@ -13,9 +13,9 @@
             <div class="pum-row-head">
                 <div class="pum-action-bar pull-right">
                     {% if object is not null %}
-                        <a href="{{ path('pa_object_edit', {beamName: beam.name, name: object_definition.name, id: object.id}) }}" class="btn btn-sm yaah-js" data-target="#pumAjaxModal" data-ya-target="#pumAjaxModal .modal-content" data-ya-location="inner">{{ 'pa.formview.create.top_btn_back'|trans({}, 'pum') }}</a>
+                        <a href="{{ path('pa_object_edit', {beamName: beam.name, name: object_definition.name, id: object.id}) }}" class="btn btn-sm yaah-js" data-target="#pumAjaxModal" data-ya-target="#pumAjaxModal .modal-content" data-ya-location="inner" data-remote="false">{{ 'pa.formview.create.top_btn_back'|trans({}, 'pum') }}</a>
                     {% else %}
-                        <a href="{{ path('pa_object_create', {beamName: beam.name, name: object_definition.name}) }}" class="btn btn-sm yaah-js" data-target="#pumAjaxModal" data-ya-target="#pumAjaxModal .modal-content" data-ya-location="inner">{{ 'pa.formview.create.top_btn_back'|trans({}, 'pum') }}</a>
+                        <a href="{{ path('pa_object_create', {beamName: beam.name, name: object_definition.name}) }}" class="btn btn-sm yaah-js" data-target="#pumAjaxModal" data-ya-target="#pumAjaxModal .modal-content" data-ya-location="inner" data-remote="false">{{ 'pa.formview.create.top_btn_back'|trans({}, 'pum') }}</a>
                     {% endif %}
                 </div>
                 {{ pum_macros.section_title('pa.formview.create.title'|trans({}, 'pum'), null, 'pa.formview.create.subtitle'|trans({ '%name%':'<strong>' ~ object_name ~ '</strong>' }, 'pum'), [

--- a/src/Pum/Bundle/ProjectAdminBundle/Resources/views/Object/create.html.twig
+++ b/src/Pum/Bundle/ProjectAdminBundle/Resources/views/Object/create.html.twig
@@ -13,7 +13,7 @@
             <div class="pum-row-head">
                 <div class="lead btn-group pull-right">
                     {% if fromUrl is defined and fromUrl %}
-                        <a href="{{ fromUrl }}" class="btn btn-default yaah-js" data-target="#pumAjaxModal" data-ya-target="#pumAjaxModal .modal-content" data-ya-location="inner">{{ 'pa.object.create.back'|trans({}, 'pum') }}</a>
+                        <a href="{{ fromUrl }}" class="btn btn-default yaah-js" data-target="#pumAjaxModal" data-ya-target="#pumAjaxModal .modal-content" data-ya-location="inner" data-remote="false">{{ 'pa.object.create.back'|trans({}, 'pum') }}</a>
                     {% endif %}
                 </div>
                 {{ pum_macros.section_title('pa.object.create.title'|trans({}, 'pum'), null, 'pa.object.create.subtitle'|trans({ '%name%':'<strong>' ~ object_name ~ '</strong>' }, 'pum'), [

--- a/src/Pum/Bundle/ProjectAdminBundle/Resources/views/Object/list.html.twig
+++ b/src/Pum/Bundle/ProjectAdminBundle/Resources/views/Object/list.html.twig
@@ -167,7 +167,7 @@
 
                             {# VIEW BUTTON #}
                             {% if is_granted('PUM_OBJ_VIEW', {project: pum_projectName(), beam: beam.name, object:object_definition.name, id: row.id}) %}
-                                <a href="{{ path('pa_object_view', {beamName: beam.name, name: object_definition.name, id: row.id, view: preferred_objectview_name, tableViewName: tableview_current_name}) }}" class="btn btn-inverse btn-sm yaah-js" data-toggle="modal" data-target="#pumAjaxModal" data-ya-target="#pumAjaxModal .modal-content" data-ya-location="inner">
+                                <a href="{{ path('pa_object_view', {beamName: beam.name, name: object_definition.name, id: row.id, view: preferred_objectview_name, tableViewName: tableview_current_name}) }}" class="btn btn-inverse btn-sm yaah-js" data-toggle="modal" data-target="#pumAjaxModal" data-ya-target="#pumAjaxModal .modal-content" data-ya-location="inner" data-remote="false">
                                     <i class="pumicon pumicon-eye"></i>
                                     <span class="visible-lg-inline-block">
                                         {{ 'pa.object.actions.btn_item_view'|trans({}, 'pum') }}
@@ -178,7 +178,7 @@
                             {# EDIT+CLONE BUTTON #}
                             {% if is_granted('PUM_OBJ_EDIT', {project: pum_projectName(), beam: beam.name, object:object_definition.name, id: row.id}) %}
                                 <div class="btn-group">
-                                    <a href="{{ path('pa_object_edit', {beamName: beam.name, name: object_definition.name, id: row.id, view: preferred_formview_name, tableViewName: tableview_current_name}) }}" class="btn pum-scheme-btn-darkgrass btn-sm yaah-js" data-toggle="modal" data-target="#pumAjaxModal" data-ya-target="#pumAjaxModal .modal-content" data-ya-location="inner">
+                                    <a href="{{ path('pa_object_edit', {beamName: beam.name, name: object_definition.name, id: row.id, view: preferred_formview_name, tableViewName: tableview_current_name}) }}" class="btn pum-scheme-btn-darkgrass btn-sm yaah-js" data-toggle="modal" data-target="#pumAjaxModal" data-ya-target="#pumAjaxModal .modal-content" data-ya-location="inner" data-remote="false">
                                         <i class="pumicon pumicon-pencil"></i>
                                         <span class="visible-lg-inline-block">
                                             {{ 'pa.object.actions.btn_item_edit'|trans({}, 'pum') }}

--- a/src/Pum/Bundle/ProjectAdminBundle/Resources/views/Object/view.html.twig
+++ b/src/Pum/Bundle/ProjectAdminBundle/Resources/views/Object/view.html.twig
@@ -82,14 +82,14 @@
                 <div class="pum-action-bar pull-right">
                     {% if is_granted('PUM_OBJ_EDIT', {project: pum_projectName(), beam: beam.name, object:object_definition.name, id: object.id}) %}
                         <div class="btn-group">
-                            <a href="{{ path('pa_object_edit', {beamName: beam.name, name: object_definition.name, id: object.id}) }}" class="btn pum-scheme-btn-darkgrass btn-sm yaah-js" data-target="#pumAjaxModal" data-ya-target="#pumAjaxModal .modal-content" data-ya-location="inner"><i class="pumicon pumicon-pencil"></i> {{ 'pa.object.view.top_btn_edit'|trans({}, 'pum') }}</a>
+                            <a href="{{ path('pa_object_edit', {beamName: beam.name, name: object_definition.name, id: object.id}) }}" class="btn pum-scheme-btn-darkgrass btn-sm yaah-js" data-target="#pumAjaxModal" data-ya-target="#pumAjaxModal .modal-content" data-ya-location="inner" data-remote="false"><i class="pumicon pumicon-pencil"></i> {{ 'pa.object.view.top_btn_edit'|trans({}, 'pum') }}</a>
                             <button type="button" class="btn pum-scheme-btn-darkgrass btn-sm dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
                                 <span class="caret"></span>
                                 <span class="sr-only">Toggle Dropdown</span>
                             </button>
                             <ul class="dropdown-menu" role="menu">
                                 <li>
-                                    <a href="{{ path('pa_object_clone', {beamName: beam.name, name: object_definition.name, id: object.id}) }}" class="text-warning yaah-js" data-target="#pumAjaxModal" data-ya-target="#pumAjaxModal .modal-content" data-ya-location="inner"><i class="pumicon pumicon-copy"></i> {{ 'pa.object.view.top_btn_clone'|trans({}, 'pum') }}</a>
+                                    <a href="{{ path('pa_object_clone', {beamName: beam.name, name: object_definition.name, id: object.id}) }}" class="text-warning yaah-js" data-target="#pumAjaxModal" data-ya-target="#pumAjaxModal .modal-content" data-ya-location="inner" data-remote="false"><i class="pumicon pumicon-copy"></i> {{ 'pa.object.view.top_btn_clone'|trans({}, 'pum') }}</a>
                                 </li>
                             </ul>
                         </div>

--- a/src/Pum/Bundle/ProjectAdminBundle/Resources/views/ObjectView/create.html.twig
+++ b/src/Pum/Bundle/ProjectAdminBundle/Resources/views/ObjectView/create.html.twig
@@ -12,7 +12,7 @@
             <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
             <div class="pum-row-head">
                 <div class="pum-action-bar pull-right">
-                    <a href="{{ path('pa_object_view', {beamName: beam.name, name: object_definition.name, id: object.id}) }}" class="btn btn-default yaah-js" data-target="#pumAjaxModal" data-ya-target="#pumAjaxModal .modal-content" data-ya-location="inner">{{ 'pa.objectview.create.top_btn_back'|trans({}, 'pum') }}</a>
+                    <a href="{{ path('pa_object_view', {beamName: beam.name, name: object_definition.name, id: object.id}) }}" class="btn btn-default yaah-js" data-target="#pumAjaxModal" data-ya-target="#pumAjaxModal .modal-content" data-ya-location="inner" data-remote="false">{{ 'pa.objectview.create.top_btn_back'|trans({}, 'pum') }}</a>
                 </div>
                 {{ pum_macros.section_title('pa.objectview.create.title'|trans({}, 'pum'), null, 'pa.objectview.create.subtitle'|trans({ '%name%':'<strong>' ~ project_name ~ '</strong>' }, 'pum'), [
                     {

--- a/src/Pum/Bundle/ProjectAdminBundle/Resources/views/ObjectView/edit.html.twig
+++ b/src/Pum/Bundle/ProjectAdminBundle/Resources/views/ObjectView/edit.html.twig
@@ -12,7 +12,7 @@
             <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
             <div class="pum-row-head">
                 <div class="pum-action-bar pull-right">
-                    <a href="{{ path('pa_object_view', {beamName: beam.name, name: object_definition.name, id: object.id, view: object_view.name}) }}" class="btn btn-default yaah-js" data-target="#pumAjaxModal" data-ya-target="#pumAjaxModal .modal-content" data-ya-location="inner">{{ 'pa.objectview.edit.top_btn_back'|trans({}, 'pum') }}</a>
+                    <a href="{{ path('pa_object_view', {beamName: beam.name, name: object_definition.name, id: object.id, view: object_view.name}) }}" class="btn btn-default yaah-js" data-target="#pumAjaxModal" data-ya-target="#pumAjaxModal .modal-content" data-ya-location="inner" data-remote="false">{{ 'pa.objectview.edit.top_btn_back'|trans({}, 'pum') }}</a>
                 </div>
                 {{ pum_macros.section_title('pa.objectview.edit.title'|trans({}, 'pum'), null, null, [
                     {


### PR DESCRIPTION
- To avoid dual request until Bootstrap remove « remote » option.
