### PR TITLE
Feature button custom translate + `pum_humanize` filter

### DIFF
--- a/src/Pum/Bundle/AppBundle/Resources/views/form.html.twig
+++ b/src/Pum/Bundle/AppBundle/Resources/views/form.html.twig
@@ -122,7 +122,7 @@
             {% set label = 'ww.form.common.submit.' ~ form.vars.name %}
         {% endif %}
     {% else %}
-        {% set label = label|humanize|pum_ucfirst %}
+        {% set label = label|pum_humanize %}
     {% endif %}
 
     {{ parent() }}
@@ -210,7 +210,7 @@
             {% set label =  pum_macros.form_get_translate_key(form) %}
         {% endif %}
         {% if label is not empty and label is not null %}
-            <legend>{{ label|trans({}, translation_domain)|humanize|pum_ucfirst }}</legend>
+            <legend>{{ label|trans({}, translation_domain)|pum_humanize }}</legend>
         {% endif %}
     {% endspaceless %}
 {% endblock collection_label %}
@@ -277,7 +277,7 @@
         {% if label is empty %}
             {% set label = pum_macros.form_get_translate_key(form)|trans({}, translation_domain) ~ ((required) ? '*' : '') %}
         {% else %}
-            {% set label = label|trans({}, translation_domain)|humanize|pum_ucfirst ~ ((required) ? '*' : '') %}
+            {% set label = label|trans({}, translation_domain)|pum_humanize ~ ((required) ? '*' : '') %}
         {% endif %}
         {{ parent() }}
     {% endif %}
@@ -294,7 +294,7 @@
             {% endif %}
             <li class="{{ loop.first ? 'active' : '' }}">
                 <a href="#{{ subform.vars.id }}" data-toggle="tab">
-                    {{ label|default(name|humanize)|trans({}, translation_domain) }}
+                    {{ label|default(name|pum_humanize)|trans({}, translation_domain) }}
                 </a>
             </li>
         {% endfor %}
@@ -328,7 +328,7 @@
     {% set label =  pum_macros.form_get_translate_key(form) %}
     <fieldset>
         {% if label is not empty and label is not null %}
-            <legend>{{ label|default(name|humanize)|trans({}, translation_domain) }}</legend>
+            <legend>{{ label|default(name|pum_humanize)|trans({}, translation_domain) }}</legend>
         {% endif %}
         {{ form_widget(form) }}
     </fieldset>
@@ -374,7 +374,7 @@
     <div class="alert {{ class|default('') }}">
         {% set label = label|trim %}
         {% if label is not empty and label is not null %}
-            {{ label|default(name|humanize)|trans({}, translation_domain)|raw }}
+            {{ label|default(name|pum_humanize)|trans({}, translation_domain)|raw }}
         {% endif %}
     </div>
     {% endif %}

--- a/src/Pum/Bundle/CoreBundle/Resources/pum_views/field/relation/default.html.twig
+++ b/src/Pum/Bundle/CoreBundle/Resources/pum_views/field/relation/default.html.twig
@@ -21,7 +21,7 @@
                                 <a href="{{ path('pa_object_view', {beamName: linkparams.beam, name: linkparams.object, id: item.id}) }}">
                             {% endif %}
                                 {% if item is empty or (item.name is defined and item.name is empty) %}
-                                    {{ identifier|humanize ~ ' #' ~ item.id }}
+                                    {{ identifier|pum_humanize ~ ' #' ~ item.id }}
                                 {% else %}
                                     {{ item }}
                                 {% endif %}
@@ -44,7 +44,7 @@
                             <a href="{{ path('pa_object_view', {beamName: linkparams.beam, name: linkparams.object, id: item.id}) }}">
                         {% endif %}
                             {% if item is empty or (item.name is defined and item.name is empty) %}
-                                {{ identifier|humanize ~ ' #' ~ item.id }}
+                                {{ identifier|pum_humanize ~ ' #' ~ item.id }}
                             {% else %}
                                 {{ item }}
                             {% endif %}

--- a/src/Pum/Bundle/CoreBundle/Twig/PumExtension.php
+++ b/src/Pum/Bundle/CoreBundle/Twig/PumExtension.php
@@ -78,6 +78,7 @@ class PumExtension extends \Twig_Extension
     public function getFilters()
     {
         return array(
+            'pum_humanize'                    => new \Twig_Filter_Method($this, 'humanize'),
             'pum_ucfirst'                     => new \Twig_Filter_Method($this, 'ucfirstFilter'),
             'pum_initials'                    => new \Twig_Filter_Method($this, 'getInitials'),
             'pum_translate_schema'            => new \Twig_Filter_Method($this, 'translateSchema'),
@@ -103,7 +104,7 @@ class PumExtension extends \Twig_Extension
         $translated = $this->getTranslator()->trans($translate, array(), 'pum_schema');
 
         if ($translated === $translate) {
-            return ucfirst(trim(strtolower(preg_replace(array('/([A-Z])/', '/[_\s]+/'), array('_$1', ' '), $default))));
+            return $this->humanize($default);
         }
 
         return $translated;
@@ -155,6 +156,14 @@ class PumExtension extends \Twig_Extension
         }
 
         return null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function humanize($input)
+    {
+        return ucfirst(trim(preg_replace(array('/[_\s]+/'), array(' '), $input)));
     }
 
     /**

--- a/src/Pum/Bundle/ProjectAdminBundle/Resources/views/Object/edit.content.html.twig
+++ b/src/Pum/Bundle/ProjectAdminBundle/Resources/views/Object/edit.content.html.twig
@@ -170,9 +170,9 @@
                                         {% endif %}
 
                                         {% if is_granted('PUM_OBJ_VIEW', {project: pum_projectName(), beam: beam.name, object:field, id: row.id}) %}
-                                            <td><a href="{{ path('pa_object_view', {beamName: beam.name, name: field, id: row.id}) }}">{{ constant('PUM_OBJECT', row)|humanize }} #{{ row.id }}</a></td>
+                                            <td><a href="{{ path('pa_object_view', {beamName: beam.name, name: field, id: row.id}) }}">{{ constant('PUM_OBJECT', row)|pum_humanize }} #{{ row.id }}</a></td>
                                         {% else %}
-                                            <td>{{ constant('PUM_OBJECT', row)|humanize }} #{{ row.id }}</td>
+                                            <td>{{ constant('PUM_OBJECT', row)|pum_humanize }} #{{ row.id }}</td>
                                         {% endif %}
 
                                         {% if tableview is null %}

--- a/src/Pum/Bundle/ProjectAdminBundle/Resources/views/Object/list.html.twig
+++ b/src/Pum/Bundle/ProjectAdminBundle/Resources/views/Object/list.html.twig
@@ -130,7 +130,7 @@
             <tbody>
                 {% if pager.getNbResults == 0 %}
                     <tr>
-                        <td class="text-center text-muted" colspan="{{ table_view_columns|length + 3 }}"><em>{{ 'pa.object.list_null'|trans({ '%name%': '<strong>' ~ object_definition.name|humanize|pum_ucfirst ~ '</strong>', '%link%':'<a href="' ~ path('pa_object_create', {beamName: beam.name, name: object_definition.name}) ~ '">', '%/link%':'</a>' }, 'pum')|raw }}</em></td>
+                        <td class="text-center text-muted" colspan="{{ table_view_columns|length + 3 }}"><em>{{ 'pa.object.list_null'|trans({ '%name%': '<strong>' ~ object_definition.name|pum_humanize ~ '</strong>', '%link%':'<a href="' ~ path('pa_object_create', {beamName: beam.name, name: object_definition.name}) ~ '">', '%/link%':'</a>' }, 'pum')|raw }}</em></td>
                     </tr>
                 {% endif %}
                 {% for row in pager %}

--- a/src/Pum/Bundle/ProjectAdminBundle/Resources/views/Object/tree.html.twig
+++ b/src/Pum/Bundle/ProjectAdminBundle/Resources/views/Object/tree.html.twig
@@ -13,17 +13,17 @@
 
 {% block content %}
     <div class="pum-row-head">
-        {{ pum_macros.section_title('pa.object.title'|trans({'%name%':object_definition.aliasName|humanize|pum_ucfirst}, "pum"), null, 'pa.object.subtitle'|trans({'%name%':'<strong>' ~ beam.aliasName|humanize|pum_ucfirst ~'</strong>'}, "pum"), [
+        {{ pum_macros.section_title('pa.object.title'|trans({'%name%':object_definition.aliasName|pum_humanize}, "pum"), null, 'pa.object.subtitle'|trans({'%name%':'<strong>' ~ beam.aliasName|pum_humanize ~'</strong>'}, "pum"), [
             {
                 href: path('pa_homepage'),
-                text: pum_project().name|pum_ucfirst
+                text: pum_project().name|pum_humanize
             },
             {
                 href: path('pa_beam_show', {beamName: beam.name}),
-                text: beam.aliasName|pum_ucfirst
+                text: beam.aliasName|pum_humanize
             },
             {
-                text: 'pa.object.description'|trans({'%name%':object_definition.aliasName|humanize|pum_ucfirst}, 'pum')
+                text: 'pa.object.description'|trans({'%name%':object_definition.aliasName|pum_humanize}, 'pum')
             }
         ]) }}
     </div>

--- a/src/Pum/Bundle/ProjectAdminBundle/Resources/views/Object/view.html.twig
+++ b/src/Pum/Bundle/ProjectAdminBundle/Resources/views/Object/view.html.twig
@@ -34,7 +34,7 @@
                     <tbody>
                     {% for row in object_view.getFields %}
                         <tr>
-                            <th class="text-right">{{ row.label|humanize|pum_ucfirst }}</th>
+                            <th class="text-right">{{ row.label|pum_humanize }}</th>
                             <td>
                                 {% if row.field.type != 'media' %}
                                     {{ pum_view_field(object, row.field.name, 'objectview') }}

--- a/src/Pum/Bundle/WoodworkBundle/Resources/views/Beam/includes/sidebar.html.twig
+++ b/src/Pum/Bundle/WoodworkBundle/Resources/views/Beam/includes/sidebar.html.twig
@@ -31,7 +31,7 @@
             {% endif %}
             {% if sidebar.objects is defined %}
                 <li class="nav-header">
-                    {{ ('ww.beams.leftnav.title_objects'|trans({'%beam%': beam.aliasName|humanize}, 'pum'))|raw }}
+                    {{ ('ww.beams.leftnav.title_objects'|trans({'%beam%': beam.aliasName|pum_humanize}, 'pum'))|raw }}
                 </li>
                 <li class="btn-group" id="js-sidebar-objects">
                     <span class="dropdown-toggle" type="button" data-toggle="dropdown">
@@ -41,7 +41,7 @@
                         {% for sidebarObject in sidebar.objects %}
                             <li title="{{ sidebarObject.aliasName }}" data-toggle="tooltip" data-placement="right" data-container="body">
                                 <a href="{{ path('ww_object_definition_edit', {beamName: beam.name, name: sidebarObject.name}) }}">
-                                    {{ sidebarObject.aliasName|humanize }}
+                                    {{ sidebarObject.aliasName|pum_humanize }}
                                 </a>
                             </li>
                         {% endfor %}

--- a/src/Pum/Bundle/WoodworkBundle/Resources/views/Group/permissions.html.twig
+++ b/src/Pum/Bundle/WoodworkBundle/Resources/views/Group/permissions.html.twig
@@ -54,7 +54,7 @@
                                     <h4 class="panel-title col-xs-6">
                                         {# Link used for toggling the project accordion to show Beams #}
                                         <a data-toggle="collapse" data-parent="#accordion" href="#project_{{ project.id }}_collapse" aria-expanded="false" aria-controls="project_{{ project.id }}_collapse">
-                                            <span class="project-title">{{ project.name|humanize }}</span>
+                                            <span class="project-title">{{ project.name|pum_humanize }}</span>
                                             <span class="project-beams-number">- {{ project.beams|length }} beams</span>
                                         </a>
                                     </h4>
@@ -125,7 +125,7 @@
                                                             <a data-toggle="collapse" href="#project_{{ project.id }}_beam_{{ beam.id }}_collapse" aria-expanded="false" aria-controls="project_{{ project.id }}_beam_{{ beam.id }}_collapse">
                                                                 {# Beam Icon #}
                                                                 <i class="pumicon pumicon-{{ beam.icon }}"></i>
-                                                                <span class="beam-title">{{ beam.name|humanize }}</span>
+                                                                <span class="beam-title">{{ beam.name|pum_humanize }}</span>
                                                                 <span class="beam-objects-number">- {{ beam.objects|length }} objects</span>
                                                             </a>
                                                         </h4>
@@ -170,7 +170,7 @@
                                                     {% for object in beam.objects %}
                                                         <div id="project_{{ project.id }}_beam_{{ beam.id }}_object_{{ object.id }}" class="container beam-object">
                                                             {# Object Title #}
-                                                            <span class="object-name col-xs-6">{{ object.name|humanize }}
+                                                            <span class="object-name col-xs-6">{{ object.name|pum_humanize }}
                                                                 {% if object.subPermissions > 0 %}
                                                                     <small>{{ 'ww.permission.object.subpermissions'|transchoice(object.subPermissions, {}, 'pum') }}</small>
                                                                 {% endif %}


### PR DESCRIPTION
- As beams & objets names, it’s now possible to add a specific
  translation for each object to « Create a new entry » and « Delete
  selected items » buttons with a `Pūm_schema.[locale].po` file
- Changes all uses of `humanize` filter to `Pūm_humanize` which does
  ignore uppercase words (instead of separating them with spaces) and
  removes forced lowercase change
