### PR TITLE
Fix SEO generator error message

### DIFF
--- a/src/Pum/Bundle/CoreBundle/Routing/PumSeoGenerator.php
+++ b/src/Pum/Bundle/CoreBundle/Routing/PumSeoGenerator.php
@@ -25,6 +25,14 @@ class PumSeoGenerator implements UrlGeneratorInterface
     {
         // Generate basic route
         if (!$name instanceof RoutableInterface && !is_array($name)) {
+            if (is_object($name)) {
+                if (null !== $routeName) {
+                    return $this->urlGenerator->generate($routeName, $parameters, $referenceType);
+                }
+
+                throw new \Exception(sprintf('Did you forget to enable Routable behavior on %s ?', get_class($name)));
+            }
+
             return $this->urlGenerator->generate($name, $parameters, $referenceType);
         }
 


### PR DESCRIPTION
- Try to call the default URL generator if the routeName is not null and
  name is an object.
- Throw an exception if the generator fail in creating a valid path.
