### PR TITLE
Update dependencies requirement + Fix ParamConverter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,12 +10,14 @@
     "require": {
         "php": ">=5.3.3",
         "symfony/symfony": "~2.6",
+        "sensio/framework-extra-bundle": "~3.0",
         "doctrine/orm": ">=2.4.1",
         "pagerfanta/pagerfanta": "~1.0",
         "imagine/imagine": "0.5.*",
         "elasticsearch/elasticsearch": "~0.4",
         "guzzlehttp/guzzle": "4.*",
-        "twig/twig": "~1.16"
+        "twig/twig": "~1.16",
+        "twig/extensions": "~1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~3.7"

--- a/src/Pum/Bundle/AppBundle/Request/ParamConverter/PumParamConverter.php
+++ b/src/Pum/Bundle/AppBundle/Request/ParamConverter/PumParamConverter.php
@@ -7,7 +7,6 @@ use Pum\Core\Definition\Beam;
 use Pum\Core\Definition\ObjectDefinition;
 use Pum\Core\Definition\Project;
 use Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter\ParamConverterInterface;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\ConfigurationInterface;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -32,10 +31,10 @@ class PumParamConverter implements ParamConverterInterface
 
     /**
      * @{inheritdoc}
-     * 
+     *
      * @throws NotFoundHttpException When invalid object given
      */
-    public function apply(Request $request, ConfigurationInterface $configuration)
+    public function apply(Request $request, ParamConverter $configuration)
     {
         $object       = null;
         $name         = $configuration->getName();
@@ -79,7 +78,7 @@ class PumParamConverter implements ParamConverterInterface
     /**
      * @{inheritdoc}
      */
-    public function supports(ConfigurationInterface $configuration)
+    public function supports(ParamConverter $configuration)
     {
         if (null === $configuration->getClass()) {
             return false;


### PR DESCRIPTION
- Update dependencies requirement (Framework Extra Bundle version +
  Twig Extensions)
- Fix ParamConverter use to be compliant with Framework Extra Bundle >=
  3.0
