### PR TITLE
Fix Behavior view / edit tab

### DIFF
--- a/src/Pum/Bundle/ProjectAdminBundle/Controller/ObjectController.php
+++ b/src/Pum/Bundle/ProjectAdminBundle/Controller/ObjectController.php
@@ -801,7 +801,7 @@ class ObjectController extends Controller
     {
         foreach ($object->getBehaviors() as $enabledBehavior) {
             $behavior = $this->getBehaviorClass($enabledBehavior);
-            if ($behavior && $behavior->isEnabled()) {
+            if ($behavior && $behavior->isEnabled() && $behavior::HAS_VIEW_TAB) {
                 $objectView->addBehavior($behavior);
             }
         }
@@ -878,7 +878,7 @@ class ObjectController extends Controller
     {
         foreach ($object->getBehaviors() as $enabledBehavior) {
             $behavior = $this->getBehaviorClass($enabledBehavior);
-            if ($behavior && $behavior->isEnabled()) {
+            if ($behavior && $behavior->isEnabled() && $behavior::HAS_EDIT_TAB) {
                 $formView->addBehavior($behavior);
             }
         }

--- a/src/Pum/Core/Behavior.php
+++ b/src/Pum/Core/Behavior.php
@@ -9,6 +9,9 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 
 abstract class Behavior implements BehaviorInterface
 {
+    const HAS_VIEW_TAB      = false;
+    const HAS_EDIT_TAB      = false;
+
     /**
      * @return boolean
      */

--- a/src/Pum/Core/Extension/Routing/Behavior/SeoBehavior.php
+++ b/src/Pum/Core/Extension/Routing/Behavior/SeoBehavior.php
@@ -16,6 +16,9 @@ class SeoBehavior extends Behavior
     const SLUG_FIELD_NAME     = 'object_slug';
     const TEMPLATE_FIELD_NAME = 'object_template';
 
+    const HAS_VIEW_TAB          = true;
+    const HAS_EDIT_TAB          = true;
+
     /**
      * @var SecurityContextInterface
      */

--- a/src/Pum/Core/Extension/Security/Behavior/SecurityUserBehavior.php
+++ b/src/Pum/Core/Extension/Security/Behavior/SecurityUserBehavior.php
@@ -14,6 +14,9 @@ class SecurityUserBehavior extends Behavior
 {
     const ROLE_FIELD_NAME     = 'object_role';
 
+    const HAS_VIEW_TAB          = true;
+    const HAS_EDIT_TAB          = true;
+
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder->add(


### PR DESCRIPTION
Remove the behavior tab from object and form view when the associated
constant of the behavior class is defined to false.
