### PR TITLE
Doctrine proxies

### DIFF
--- a/src/Pum/Bundle/CoreBundle/DependencyInjection/PumCoreExtension.php
+++ b/src/Pum/Bundle/CoreBundle/DependencyInjection/PumCoreExtension.php
@@ -69,7 +69,7 @@ class PumCoreExtension extends Extension
         if ($config['doctrine']) {
             $definitionService = $container->getDefinition('pum_core.em_factory');
             $isDevMode         = ('dev' == $container->getParameter('kernel.environment')) ? true : false;
-            $proxyDir          = null;
+            $proxyDir          = $container->getParameter('kernel.cache_dir') . DIRECTORY_SEPARATOR . 'pum_proxies';
             $cache             = null;
 
             foreach ($config['doctrine'] as $key => $values) {


### PR DESCRIPTION
Force doctrine proxies to be generated in sf2 cache folder instead of
tmp directory
