### PR TITLE
Fix doctrine relation

### DIFF
--- a/src/Pum/Core/Extension/Core/Type/RelationType.php
+++ b/src/Pum/Core/Extension/Core/Type/RelationType.php
@@ -529,7 +529,7 @@ class RelationType extends AbstractType
                 $relationCascade = array_merge(array('persist'), $cascade);
                 $attributes = array(
                     'fieldName'     => $camel,
-                    'cascade'       => $relationCascade,
+                    'cascade'      => array('persist'),
                     'targetEntity'  => $targetClass,
                     'inversedBy'    => $inversedBy,
                     'orphanRemoval' => false,
@@ -555,7 +555,7 @@ class RelationType extends AbstractType
                 $relationCascade = array_merge(array('persist'), $cascade);
                 $attributes = array(
                     'fieldName'    => $camel,
-                    'cascade'      => $relationCascade,
+                    'cascade'      => array('persist'),
                     'targetEntity' => $targetClass,
                     'inversedBy'   => $inversedBy,
                     'joinColumns' => array(


### PR DESCRIPTION
Avoid Doctrine to remove a parent relation when a children is removed and cascade remove is set to many-to-one relation type.
