### PR TITLE
Fix setCc to addBcc in Notification service

### DIFF
--- a/src/Pum/Core/Extension/Notification/Service/NotificationService.php
+++ b/src/Pum/Core/Extension/Notification/Service/NotificationService.php
@@ -156,7 +156,7 @@ class NotificationService
 
         foreach ($ccis as $cci) {
             if(false !== filter_var($cci, FILTER_VALIDATE_EMAIL)) {
-                $message->setCc($cci);
+                $message->addBcc($cci);
             }
         }
 


### PR DESCRIPTION
Fix "setCc" to "addBcc" in Notification service. Cc mails were overrided by last mail of the array.
