### PR TITLE
Change PUM's objects' proxies generation directory

### DIFF
--- a/src/Pum/Bundle/CoreBundle/DependencyInjection/PumCoreExtension.php
+++ b/src/Pum/Bundle/CoreBundle/DependencyInjection/PumCoreExtension.php
@@ -67,7 +67,7 @@ class PumCoreExtension extends Extension
         if ($config['doctrine']) {
             $definitionService = $container->getDefinition('pum_core.em_factory');
             $isDevMode         = ('dev' == $container->getParameter('kernel.environment')) ? true : false;
-            $proxyDir          = null;
+            $proxyDir          = $container->getParameter('kernel.cache_dir').'/doctrine/orm/Proxies';
             $cache             = null;
 
             foreach ($config['doctrine'] as $key => $values) {


### PR DESCRIPTION
Change PUM's objects' proxies generation directory from /tmp to symfony's default cache directory